### PR TITLE
Refactor to pathlib and improve docs

### DIFF
--- a/src/LeanRAG/LeanIO.py
+++ b/src/LeanRAG/LeanIO.py
@@ -1,11 +1,16 @@
-import subprocess, asyncio, os, json, shutil, requests
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import requests
 from pathlib import Path
 from typing import Tuple, Optional
 from urllib.parse import quote
 
 
 
-async def run_lean_command(command, project_dir=os.getcwd()):
+async def run_lean_command(command, project_dir: str | Path = Path.cwd()):
     """
     Run a Lean command asynchronously and return the output.
     """
@@ -14,7 +19,7 @@ async def run_lean_command(command, project_dir=os.getcwd()):
         *command,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        cwd=project_dir
+        cwd=str(Path(project_dir)),
     )
 
     stdout, stderr = await process.communicate()


### PR DESCRIPTION
## Summary
- switch remaining path handling to `pathlib.Path`
- keep backwards compatibility for functions that accept string paths
- add documentation strings for public utilities and Retriever methods

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_684c495a120c8328bdb607e7c9cf8420